### PR TITLE
Codeable routes

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,29 @@ return utils.loadAsync('../resources/person_dino.json', fs)
 	- stringified OpenApi (swagger) document.
 	- formatters dictionary: This contains formatters for the path _**pathFormatter**_ and for the resource _**resourceFormatter**_ The formatters take a path parameter and return a string.
 
+The data returned takes the following format:
+```
+{ basepath: string,
+  resources: { "resourceName": [ {  method: string, // method is one of: "post",
+                                                    //                   "put",
+                                                    //                   "delete",
+                                                    //                   "get",
+                                                    //                   "patch"
+                                    route: string, // path to register
+                                    params: [ { model: string, // model name
+                                                array: boolean, // is this an array? }
+                                    ],
+                                    responses: [ { model: string, // model name
+                                                   array: boolean, // is this an array? }
+                                    ]
+                                 }
+                               ]
+             },
+  models: [ models declarations ]
+}
+```
+
+
 ```javascript
 var swaggerize = require('ibm-openapi-support')
 var swaggerizeUtils = require('ibm-openapi-support/utils')

--- a/test/resources/person_dino.json
+++ b/test/resources/person_dino.json
@@ -23,6 +23,62 @@
             }
           }
         }
+      },
+      "post": {
+        "description": "Post `Person` objects.",
+        "produces": [
+          "application/json"
+        ],
+	"parameters": [
+	  {
+	  "in": "body",
+	  "name": "ageobj",
+	  "description": "age of person to post",
+	  "required": true,
+	  "schema": {
+	    "$ref": "#/definitions/age"
+	    }
+  	  }
+	],
+        "responses": {
+          "200": {
+            "description": "A list of Persons",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/age"
+              }
+            }
+          }
+        }
+      }
+    },
+    "/persons/{id}": {
+      "get": {
+        "description": "Gets `Person` objects.",
+        "produces": [
+          "application/json"
+        ],
+	"parameters": [
+	{
+	"in": "path",
+	"name": "id",
+	"description": "ID of person to return",
+	"required": true,
+	"type": "string"
+	}
+	],
+        "responses": {
+          "200": {
+            "description": "A list of Persons",
+            "schema": {
+              "type": "array",
+              "items": {
+                "$ref": "#/definitions/age"
+              }
+            }
+          }
+        }
       }
     },
     "/dinosaurs": {

--- a/test/unit/swaggerize.js
+++ b/test/unit/swaggerize.js
@@ -181,9 +181,12 @@ describe('swagger generator', function () {
 
     it('returned parsed swagger dict contains expected values', function () {
       assert(parsedSwagger.basepath === '/basepath')
-      assert(Object.keys(parsedSwagger.resources).length === 2)
-      assert(parsedSwagger.resources['/persons'])
-      assert(parsedSwagger.resources['/dinosaurs'])
+      assert(Object.keys(parsedSwagger.resources).length === 3)
+      assert(parsedSwagger.resources['/persons'][0]['params'].length === 0)
+      assert(parsedSwagger.resources['/persons'][1]['params'][0]['model'] === 'age')
+      assert(parsedSwagger.resources['/persons'][1]['params'][0]['array'] === false)
+      assert(parsedSwagger.resources['/persons'][1]['responses'][0]['model'] === 'age')
+      assert(parsedSwagger.resources['/persons'][1]['responses'][0]['array'] === true)
       assert(Object.keys(parsedSwagger.refs).length === 3)
       assert(parsedSwagger.refs['age'])
       assert(parsedSwagger.refs['dino'])


### PR DESCRIPTION
I have added two additional keys into the returned resources object: params and responses. These keys contain lists of objects that identify the structured data passed to and returned from an API call. The objects contain two keys: model (the name of the model) and isArray to indicate if an array of the model type was passed.

I have also added 201 and a valid response code to search when compiling the response list. 